### PR TITLE
Create charger stats screen

### DIFF
--- a/Prototype Development/Core/Inc/display.h
+++ b/Prototype Development/Core/Inc/display.h
@@ -5,5 +5,8 @@
 void SRE_Display_Init(bool test_mode);
 void SRE_Display_Test();
 void SRE_Display_Nav();
+void SRE_Display_Title_Bar(char title[]);
+void SRE_Display_Nav_Bar(char *buttons[], int numOfButtons, int firstButtonIndex);
+void SRE_Display_Charger_Stats();
 
 #endif

--- a/Prototype Development/Core/Inc/display.h
+++ b/Prototype Development/Core/Inc/display.h
@@ -5,8 +5,6 @@
 void SRE_Display_Init(bool test_mode);
 void SRE_Display_Test();
 void SRE_Display_Nav();
-void SRE_Display_Title_Bar(char title[]);
-void SRE_Display_Nav_Bar(char *buttons[], int numOfButtons, int firstButtonIndex);
 void SRE_Display_Charger_Stats();
 
 #endif

--- a/Prototype Development/Core/Src/display.c
+++ b/Prototype Development/Core/Src/display.c
@@ -5,13 +5,11 @@
 #include "ssd1306_fonts.h"
 #include <string.h>
 
-
-
 // Initialization function
 void SRE_Display_Init(bool test_mode) {
 	ssd1306_Init();
 	if (test_mode) {
-		 SRE_Display_Charger_Stats();
+		 SRE_Display_Display_Test();
 	}
 }
 

--- a/Prototype Development/Core/Src/display.c
+++ b/Prototype Development/Core/Src/display.c
@@ -9,7 +9,7 @@
 void SRE_Display_Init(bool test_mode) {
 	ssd1306_Init();
 	if (test_mode) {
-		 SRE_Display_Display_Test();
+		 SRE_Display_Test();
 	}
 }
 

--- a/Prototype Development/Core/Src/display.c
+++ b/Prototype Development/Core/Src/display.c
@@ -2,14 +2,19 @@
 #include <stdbool.h>
 #include "display.h"
 #include "ssd1306.h"
+#include "ssd1306_fonts.h"
+#include <string.h>
+
+
 
 // Initialization function
 void SRE_Display_Init(bool test_mode) {
 	ssd1306_Init();
 	if (test_mode) {
-		SRE_Display_Test();
+		 SRE_Display_Charger_Stats();
 	}
 }
+
 
 // Function to test display
 void SRE_Display_Test() {
@@ -21,3 +26,57 @@ void SRE_Display_Test() {
 void SRE_Display_Nav() {
 
 }
+
+void SRE_Display_Charger_Stats() {
+
+	while (!selectPressed) {
+
+		ssd1306_FillRectangle(0, 0, 127, 63, Black);
+
+
+		int numOfButtons = 2;
+		if (selectedButton > numOfButtons-1) {
+			selectedButton = 0;
+		}
+		if (selectedButton < 0) {
+			selectedButton = numOfButtons-1;
+		}
+
+
+		bool errors = false;
+		char chargerTempString[25] = "Charger Tmp: 100.22C";
+
+
+		SRE_Display_Title_Bar("Charger Stats");
+
+		ssd1306_SetCursor(1, 13);
+		ssd1306_WriteString(chargerTempString, Font_6x8, White);
+
+		ssd1306_SetCursor(1, 23);
+
+		if (errors) {
+			ssd1306_WriteString("Errors detected", Font_6x8, White);
+		}
+		else {
+			ssd1306_WriteString("No errors detected", Font_6x8, White);
+		}
+
+
+		char *navBarButtons[] = {"Batt", "Nav"};
+		SRE_Display_Nav_Bar(navBarButtons, numOfButtons, 0);
+
+		ssd1306_UpdateScreen();
+	}
+
+	if (selectPressed) {
+		selectPressed = false;
+		if (selectedButton == 0 ) {
+			// go to Batt sreen
+		}
+		else if (selectedButton == 1) {
+			//go to Navigation screen
+		}
+	}
+}
+
+


### PR DESCRIPTION
Resolves #11 
The missing pixels are because of a damaged OLED display, not the software

[
![Charger_Stats_Screeb](https://github.com/user-attachments/assets/fd254e20-43bb-4701-a8d9-b669e85a46fb)
](url)